### PR TITLE
Correct versioning for first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Unreleased #
 
+# 0.1.0 #
+
 * Use coverage kit to enforce maximum coverage
-
-# 1.0.1 #
-
 * Updated params for feed to allow code and category
 * Added a method to build a review image
 * Fix issue with caching forever
 * Fix issue when feedback result blank
-
-# 0.0.1 #
-
-* Initial Release

--- a/lib/feefo/version.rb
+++ b/lib/feefo/version.rb
@@ -1,3 +1,3 @@
 module Feefo
-  VERSION = '1.0.1'
+  VERSION = '0.1.0'
 end


### PR DESCRIPTION
1.0.1 was never released, it's not even a logic version. Really 0.1.0 is the first release, hence correcting the changelog in preparation for a release.